### PR TITLE
feat(ui): neon-noir redesign of the web shell

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "wavesurfer.js": "^6.6.4"
       },
       "devDependencies": {
+        "playwright": "^1.60.0",
         "web-vitals": "^4.2.4"
       }
     },
@@ -11980,6 +11981,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -16118,19 +16166,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -17712,8 +17747,7 @@
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "requires": {}
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -18688,14 +18722,12 @@
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
-      "requires": {}
+      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g=="
     },
     "@csstools/selector-specificity": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-      "requires": {}
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -19833,8 +19865,7 @@
     "@vercel/speed-insights": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.1.0.tgz",
-      "integrity": "sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==",
-      "requires": {}
+      "integrity": "sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -20022,8 +20053,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -20092,8 +20122,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -20409,8 +20438,7 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "requires": {}
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
@@ -21080,8 +21108,7 @@
     "css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
-      "requires": {}
+      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g=="
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -21129,8 +21156,7 @@
     "css-prefers-color-scheme": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "requires": {}
+      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA=="
     },
     "css-select": {
       "version": "4.3.0",
@@ -21229,8 +21255,7 @@
     "cssnano-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "requires": {}
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
     },
     "csso": {
       "version": "4.2.0",
@@ -22109,8 +22134,7 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-      "requires": {}
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ=="
     },
     "eslint-plugin-testing-library": {
       "version": "5.11.1",
@@ -23072,8 +23096,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "idb": {
       "version": "7.1.1",
@@ -23799,8 +23822,7 @@
     "jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "requires": {}
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -25069,6 +25091,31 @@
         }
       }
     },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
+    },
     "possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -25095,8 +25142,7 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "requires": {}
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -25194,26 +25240,22 @@
     "postcss-discard-comments": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "requires": {}
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "requires": {}
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "requires": {}
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "requires": {}
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
     },
     "postcss-double-position-gradients": {
       "version": "3.1.2",
@@ -25235,8 +25277,7 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "requires": {}
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -25257,14 +25298,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
-      "requires": {}
+      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg=="
     },
     "postcss-image-set-function": {
       "version": "4.0.7",
@@ -25287,8 +25326,7 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "requires": {}
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
     },
     "postcss-js": {
       "version": "4.0.1",
@@ -25341,14 +25379,12 @@
     "postcss-logical": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "requires": {}
+      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g=="
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "requires": {}
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
     },
     "postcss-merge-longhand": {
       "version": "5.1.7",
@@ -25409,8 +25445,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "requires": {}
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.2.0",
@@ -25490,8 +25525,7 @@
     "postcss-normalize-charset": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "requires": {}
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -25562,8 +25596,7 @@
     "postcss-opacity-percentage": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
-      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
-      "requires": {}
+      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A=="
     },
     "postcss-ordered-values": {
       "version": "5.1.3",
@@ -25585,8 +25618,7 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -25680,8 +25712,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "6.0.1",
@@ -27125,8 +27156,7 @@
     "style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
-      "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==",
-      "requires": {}
+      "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w=="
     },
     "stylehacks": {
       "version": "5.1.1",
@@ -27667,12 +27697,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -27990,8 +28014,7 @@
         "ws": {
           "version": "8.18.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-          "requires": {}
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="
         }
       }
     },
@@ -28455,8 +28478,7 @@
     "ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "requires": {}
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "devDependencies": {
+    "playwright": "^1.60.0",
     "web-vitals": "^4.2.4"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,18 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#0a0b0f" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Retro VST — neon-noir host for legacy VST effects. Process your audio through analog ghosts."
+    />
+
+    <!-- Neon-noir typography: condensed techno display + Esper-readout mono -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +32,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>RETRO·VST // analog ghosts</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/scripts/shoot.mjs
+++ b/scripts/shoot.mjs
@@ -1,0 +1,33 @@
+// Dev helper: screenshot key states of the app for visual review.
+// Usage: node scripts/shoot.mjs [baseUrl]
+import { chromium } from "playwright";
+
+const base = process.argv[2] || "http://localhost:3000";
+const out = "/tmp";
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1320, height: 920 } });
+
+await page.goto(base, { waitUntil: "networkidle" });
+await page.waitForTimeout(2200);
+await page.screenshot({ path: `${out}/retro-home.png` });
+console.log("home ✓");
+
+// open first rack unit -> modal
+await page.locator(".rack-unit").first().click();
+await page.waitForTimeout(900);
+await page.screenshot({ path: `${out}/retro-modal.png` });
+console.log("modal ✓");
+
+// open login modal (close plugin modal first via ESC)
+await page.keyboard.press("Escape");
+await page.waitForTimeout(400);
+const loginBtn = page.locator(".hw-btn-amber");
+if (await loginBtn.count()) {
+  await loginBtn.first().click();
+  await page.waitForTimeout(700);
+  await page.screenshot({ path: `${out}/retro-login.png` });
+  console.log("login ✓");
+}
+
+await browser.close();

--- a/src/App.js
+++ b/src/App.js
@@ -1,50 +1,54 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Cookie from "js-cookie"; // Importa a biblioteca js-cookie
 import Navbar from "./components/Navbar";
 import PluginGrid from "./components/PluginGrid";
 import PluginModal from "./components/PluginModal";
 import LoginModal from "./components/LoginModal";
+import { useToast } from "./components/Toast";
 import "./styles/App.css";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import plugins from "./Plugin.json";
 
 function App() {
+  const toast = useToast();
   const [selectedPlugin, setSelectedPlugin] = useState(null);
   const [paramValues, setParamValues] = useState([]);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [profile, setProfile] = useState(null);
 
-  // Ao carregar a página, verifica se existe token no cookie
-  // Se existir, faz uma requisição para a rota /profile para obter os dados do usuário
-  useEffect(() => {
+  // Busca o profile a partir do token; usada no boot e logo após o login,
+  // evitando o window.location.reload() que existia antes.
+  const fetchProfile = useCallback(async () => {
     const token = Cookie.get("authToken");
-    if (token) {
-      const fetchProfile = async () => {
-        try {
-          // Alterado de "/profile" para "/api/profile"
-          const response = await fetch(
-            process.env.REACT_APP_API_GO_URL + "/api/profile",
-            {
-              method: "GET",
-              headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${token}`
-              }
-            }
-          );
-          if (response.ok) {
-            const profileData = await response.json();
-            setProfile(profileData);
-          } else {
-            console.error("Error fetching profile data", response.status);
-          }
-        } catch (error) {
-          console.error("Error fetching profile:", error);
+    if (!token) return;
+    try {
+      const response = await fetch(
+        process.env.REACT_APP_API_GO_URL + "/api/profile",
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
         }
-      };
-      fetchProfile();
+      );
+      if (response.ok) {
+        setProfile(await response.json());
+      } else if (response.status === 401) {
+        // token expirado/inválido — limpa silenciosamente
+        Cookie.remove("authToken");
+        setProfile(null);
+      } else {
+        console.error("Error fetching profile data", response.status);
+      }
+    } catch (error) {
+      console.error("Error fetching profile:", error);
     }
   }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
 
   const openModal = (plugin) => {
     setSelectedPlugin(plugin);
@@ -72,34 +76,52 @@ function App() {
     setParamValues(updated);
   };
 
-  const toggleLoginModal = () => {
-    setShowLoginModal((prev) => !prev);
-  };
+  const openLoginModal = () => setShowLoginModal(true);
+  const closeLoginModal = () => setShowLoginModal(false);
 
-  // Ao fazer login ou signup, salva o token no cookie e recarrega a página
-  const handleLogin = ({ profile, token }) => {
+  // Ao fazer login/signup: salva o token e busca o profile sem reload.
+  // O fechamento da modal fica a cargo do onClose do LoginModal (evita
+  // dois setState concorrentes que reabriam a modal).
+  const handleLogin = ({ token }) => {
     Cookie.set("authToken", token);
-    // Recarrega a página para disparar a lógica de carregamento do profile
-    window.location.reload();
+    fetchProfile();
   };
 
-  // Logout: remove o token do cookie e recarrega a página
   const handleLogout = () => {
     Cookie.remove("authToken");
-    window.location.reload();
+    setProfile(null);
+    toast.info("Signed out.");
   };
 
   return (
-    <div className="app retro-theme full-height">
+    <div className="app">
+      {/* atmospheric layers (behind content) */}
+      <div className="atmosphere" aria-hidden="true" />
+      <div className="rain" aria-hidden="true" />
+
       <Navbar
         profile={profile}
         onLogout={handleLogout}
         credits={profile ? profile.current_balance : 42.5}
-        onLoginClick={toggleLoginModal}
+        onLoginClick={openLoginModal}
       />
-      <div className="main-content">
+
+      <main className="main-content">
         <SpeedInsights />
-        <h1 className="title">Retro VST Effects</h1>
+
+        <header className="hero">
+          <div className="hero-kicker">analog ghosts · vst host</div>
+          <h1 className="title" data-text="RETRO·VST">
+            RETRO<span className="accent">·</span>VST
+          </h1>
+          <p className="hero-sub">
+            Run your audio through legacy VST effects, hosted on the wire.
+            Rack them up. Dial them in. Hear the rain.
+          </p>
+        </header>
+
+        <div className="section-rule">{"// effects rack"}</div>
+
         <PluginGrid plugins={plugins} onPluginClick={openModal} />
 
         {selectedPlugin && (
@@ -112,9 +134,13 @@ function App() {
         )}
 
         {showLoginModal && (
-          <LoginModal onClose={toggleLoginModal} onLogin={handleLogin} />
+          <LoginModal onClose={closeLoginModal} onLogin={handleLogin} />
         )}
-      </div>
+      </main>
+
+      {/* foreground film/CRT layers (never block input) */}
+      <div className="grain" aria-hidden="true" />
+      <div className="crt-overlay" aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/Knob.js
+++ b/src/components/Knob.js
@@ -1,0 +1,154 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import "../styles/Knob.css";
+
+/*
+ * Skeuomorphic analog knob — metal/bakelite body with an amber LED arc.
+ * Drag vertically (up = increase) or use the mouse wheel. Double-click resets
+ * to defaultValue. Replaces the flat rc-slider for that hardware feel.
+ */
+
+const SWEEP = 270;          // total rotation arc in degrees
+const START = -135;         // pointer angle at min value
+const DRAG_RANGE = 180;     // px of vertical drag for full min→max travel
+
+// SVG arc geometry
+const R = 42;
+const C = 50;
+const CIRC = 2 * Math.PI * R;
+
+function describeArc(ratio) {
+  // length of the lit portion of the ring (sweep is 270° of the full circle)
+  const lit = (SWEEP / 360) * CIRC * ratio;
+  const gap = CIRC - lit;
+  return { dash: `${lit} ${gap}` };
+}
+
+function Knob({
+  value,
+  min = 0,
+  max = 1,
+  step = 0.01,
+  defaultValue,
+  onChange,
+  label,
+  unit = "",
+  disabled = false,
+  format,
+  color = "sodium", // sodium | cyan | blood
+}) {
+  const ratio = Math.min(1, Math.max(0, (value - min) / (max - min || 1)));
+  const angle = START + ratio * SWEEP;
+  const { dash } = describeArc(ratio);
+
+  const [dragging, setDragging] = useState(false);
+  const drag = useRef({ startY: 0, startVal: 0 });
+
+  const clampStep = useCallback(
+    (raw) => {
+      const clamped = Math.min(max, Math.max(min, raw));
+      const snapped = Math.round((clamped - min) / step) * step + min;
+      return parseFloat(snapped.toFixed(6));
+    },
+    [min, max, step]
+  );
+
+  const onPointerDown = (e) => {
+    if (disabled) return;
+    e.preventDefault();
+    drag.current = { startY: e.clientY, startVal: value };
+    setDragging(true);
+  };
+
+  useEffect(() => {
+    if (!dragging) return;
+    const move = (e) => {
+      const dy = drag.current.startY - e.clientY; // up is positive
+      const deltaRatio = dy / DRAG_RANGE;
+      const raw = drag.current.startVal + deltaRatio * (max - min);
+      onChange(clampStep(raw));
+    };
+    const up = () => setDragging(false);
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, [dragging, max, min, onChange, clampStep]);
+
+  const onWheel = (e) => {
+    if (disabled) return;
+    e.preventDefault();
+    const dir = e.deltaY < 0 ? 1 : -1;
+    onChange(clampStep(value + dir * step));
+  };
+
+  const onDoubleClick = () => {
+    if (disabled || defaultValue === undefined) return;
+    onChange(clampStep(defaultValue));
+  };
+
+  const display = format ? format(value) : Number(value).toFixed(2);
+
+  return (
+    <div
+      className={`knob knob-${color} ${disabled ? "is-disabled" : ""} ${
+        dragging ? "is-dragging" : ""
+      }`}
+    >
+      {label && <div className="knob-label">{label}</div>}
+
+      <div
+        className="knob-dial"
+        onPointerDown={onPointerDown}
+        onWheel={onWheel}
+        onDoubleClick={onDoubleClick}
+        role="slider"
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={(e) => {
+          if (disabled) return;
+          if (e.key === "ArrowUp" || e.key === "ArrowRight")
+            onChange(clampStep(value + step));
+          if (e.key === "ArrowDown" || e.key === "ArrowLeft")
+            onChange(clampStep(value - step));
+        }}
+      >
+        {/* LED arc ring */}
+        <svg className="knob-ring" viewBox="0 0 100 100">
+          <circle
+            className="knob-ring-track"
+            cx={C}
+            cy={C}
+            r={R}
+            transform={`rotate(${START - 90} ${C} ${C})`}
+            strokeDasharray={`${(SWEEP / 360) * CIRC} ${CIRC}`}
+          />
+          <circle
+            className="knob-ring-lit"
+            cx={C}
+            cy={C}
+            r={R}
+            transform={`rotate(${START - 90} ${C} ${C})`}
+            strokeDasharray={dash}
+          />
+        </svg>
+
+        {/* metal cap with pointer */}
+        <div className="knob-cap" style={{ transform: `rotate(${angle}deg)` }}>
+          <span className="knob-pointer" />
+        </div>
+      </div>
+
+      <div className="knob-readout">
+        {display}
+        {unit && <span className="knob-unit">{unit}</span>}
+      </div>
+    </div>
+  );
+}
+
+export default Knob;

--- a/src/components/LoginModal.js
+++ b/src/components/LoginModal.js
@@ -1,14 +1,16 @@
 import React, { useState } from "react";
 import "../styles/LoginModal.css";
+import { useToast } from "./Toast";
 
 function LoginModal({ onClose, onLogin }) {
+  const toast = useToast();
   const [fullName, setFullName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSignup, setIsSignup] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
+  const [busy, setBusy] = useState(false);
 
-  // Alterna entre Login e Signup e limpa mensagens de erro
   const handleToggleMode = () => {
     setIsSignup((prev) => !prev);
     setErrorMsg("");
@@ -16,22 +18,13 @@ function LoginModal({ onClose, onLogin }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const endpoint = isSignup ? "/signup" : "/login";
+    setErrorMsg("");
+    setBusy(true);
 
-    // Para o signup, envia as chaves em minúsculas conforme o esperado pela API
-    let requestBody;
-    if (isSignup) {
-      requestBody = {
-        name: fullName, // Alterado de "Name" para "name"
-        email: email,
-        password: password,
-      };
-    } else {
-      requestBody = {
-        email: email,
-        password: password,
-      };
-    }
+    const endpoint = isSignup ? "/signup" : "/login";
+    const requestBody = isSignup
+      ? { name: fullName, email, password }
+      : { email, password };
 
     try {
       const url = process.env.REACT_APP_API_GO_URL + endpoint;
@@ -44,59 +37,78 @@ function LoginModal({ onClose, onLogin }) {
       const data = await response.json();
 
       if (response.ok) {
-        const token = data.token;
-        // Exibe somente a mensagem, sem o token
-        alert(data.message);
-        onLogin({ profile: data.profile, token });
+        toast.ok(data.message || (isSignup ? "Account created." : "Welcome back."));
+        onLogin({ token: data.token });
         onClose();
       } else {
-        const errorMessage = data.error || data.message || "Unknown error";
-        setErrorMsg(errorMessage);
+        setErrorMsg(data.error || data.message || "Unknown error");
       }
     } catch (err) {
       console.error(err);
       setErrorMsg("Error connecting to the server.");
+    } finally {
+      setBusy(false);
     }
   };
 
   return (
-    <div className="login-modal">
-      <div className="login-modal-content">
-        <button className="close-button" onClick={onClose}>
-          ✖
+    <div
+      className="login-modal"
+      onClick={(e) => e.target.classList.contains("login-modal") && onClose()}
+    >
+      <div className="login-panel">
+        <button className="panel-close" onClick={onClose} aria-label="Close">
+          ✕
         </button>
-        <h2>{isSignup ? "Sign Up" : "Login"}</h2>
-        <form onSubmit={handleSubmit}>
+
+        <div className="login-head">
+          <span className="led" />
+          <span className="login-kicker">
+            {isSignup ? "// new credentials" : "// access terminal"}
+          </span>
+        </div>
+        <h2 className="login-title">{isSignup ? "Sign Up" : "Login"}</h2>
+
+        <form onSubmit={handleSubmit} className="login-form">
           {isSignup && (
+            <label className="field">
+              <span className="field-label">Full Name</span>
+              <input
+                type="text"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                required
+                autoFocus
+              />
+            </label>
+          )}
+          <label className="field">
+            <span className="field-label">Email</span>
             <input
-              type="text"
-              placeholder="Full Name"
-              value={fullName}
-              onChange={(e) => setFullName(e.target.value)}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
               required
             />
-          )}
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-          <button type="submit">{isSignup ? "Sign Up" : "Login"}</button>
+          </label>
+          <label className="field">
+            <span className="field-label">Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </label>
+
+          {errorMsg && <p className="error-msg">{errorMsg}</p>}
+
+          <button type="submit" className="login-submit" disabled={busy}>
+            {busy ? "···" : isSignup ? "Create account" : "Authenticate"}
+          </button>
         </form>
 
-        {/* Exibe a mensagem de erro, se houver */}
-        {errorMsg && <p className="error-msg">{errorMsg}</p>}
-
-        <button onClick={handleToggleMode} className="toggle-mode-button">
+        <button onClick={handleToggleMode} className="toggle-mode">
           {isSignup
             ? "Already have an account? Login"
             : "Don't have an account? Sign Up"}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -3,35 +3,45 @@ import "../styles/Navbar.css";
 
 function Navbar({ profile, onLogout, credits, onLoginClick }) {
   return (
-    <nav className="navbar">
-      {/* Lado esquerdo: exibe o nome e os créditos do usuário (em duas linhas) ou "Guest" se não estiver logado */}
-      <div className="navbar-left">
-        {profile ? (
-          <div className="profile-info">
-            <div className="profile-name">{profile.full_name}</div>
-            <div className="profile-credits">Credits: {profile.current_balance}</div>
-          </div>
-        ) : (
-          <div className="guest-info">
-            <span className="navbar-user">Guest</span>
-          </div>
-        )}
-      </div>
+    <nav className="navbar metal">
+      <div className="navbar-inner">
+        {/* Brand — small neon wordmark + power LED */}
+        <div className="navbar-brand">
+          <span className="led" />
+          <span className="brand-mark">RETRO<span>·</span>VST</span>
+          <span className="brand-tag">{"// vst host"}</span>
+        </div>
 
-      {/* Centro: Título da aplicação */}
-      <div className="navbar-center">Retro VST Effects</div>
-
-      {/* Lado direito: exibe o botão de logout se estiver logado; caso contrário, exibe o botão de Login/Signup */}
-      <div className="navbar-right">
-        {profile ? (
-          <button className="login-btn" onClick={onLogout}>
-            Logout
-          </button>
-        ) : (
-          <button className="login-btn" onClick={onLoginClick}>
-            Login / Signup
-          </button>
-        )}
+        {/* Right — credits readout + auth */}
+        <div className="navbar-right">
+          {profile ? (
+            <>
+              <div className="credits-readout" title="Account balance">
+                <span className="credits-label">CR</span>
+                <span className="credits-value">
+                  {Number(credits ?? 0).toFixed(2)}
+                </span>
+              </div>
+              <div className="profile-chip">
+                <span className="led cyan" />
+                <span className="profile-name">{profile.full_name}</span>
+              </div>
+              <button className="hw-btn" onClick={onLogout}>
+                Logout
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="profile-chip guest">
+                <span className="led off" />
+                <span className="profile-name">Guest</span>
+              </div>
+              <button className="hw-btn hw-btn-amber" onClick={onLoginClick}>
+                Login / Signup
+              </button>
+            </>
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/PluginGrid.js
+++ b/src/components/PluginGrid.js
@@ -5,16 +5,41 @@ import "../styles/PluginGrid.css";
 function PluginGrid({ plugins, onPluginClick }) {
   return (
     <div className="plugin-grid">
-      {plugins.map((plugin) => (
-        <div
-          key={plugin.id}
-          className="plugin-card"
-          onClick={() => onPluginClick(plugin)}
-        >
-          <h2>{plugin.label}</h2>
-          <p>{plugin.description}</p>
-        </div>
-      ))}
+      {plugins.map((plugin) => {
+        const paramCount = plugin.parameters ? plugin.parameters.length : 0;
+        return (
+          <button
+            key={plugin.id}
+            className="rack-unit"
+            onClick={() => onPluginClick(plugin)}
+            type="button"
+          >
+            {/* corner screws */}
+            <span className="screw screw-tl" />
+            <span className="screw screw-tr" />
+            <span className="screw screw-bl" />
+            <span className="screw screw-br" />
+
+            <div className="rack-head">
+              <span className="led" />
+              <span className="rack-id">
+                UNIT&nbsp;{String(plugin.id).padStart(2, "0")}
+              </span>
+              <span className="rack-slug">{plugin.name}</span>
+            </div>
+
+            <h2 className="rack-title">{plugin.label}</h2>
+            <p className="rack-desc">{plugin.description}</p>
+
+            <div className="rack-foot">
+              <span className="rack-params">
+                {paramCount} {paramCount === 1 ? "param" : "params"}
+              </span>
+              <span className="rack-engage">ENGAGE ▸</span>
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/PluginModal.js
+++ b/src/components/PluginModal.js
@@ -1,46 +1,65 @@
-import React, { useState } from "react";
-import Slider from "rc-slider";
-import "rc-slider/assets/index.css";
+import React, { useEffect, useRef, useState } from "react";
 import "../styles/PluginModal.css";
 
-import WaveformSelector from "./WaveformSelector"; // Componente para preview da waveform
+import Knob from "./Knob";
+import WaveformSelector from "./WaveformSelector";
+import { useToast } from "./Toast";
+
+const ALLOWED = ["wav", "mp3", "ogg", "flac", "aiff"];
+const MAX_BYTES = 80 * 1024 * 1024;
 
 function PluginModal({ plugin, onClose, paramValues, onParameterChange }) {
+  const toast = useToast();
   const [file, setFile] = useState(null);
   const [previewStartTime, setPreviewStartTime] = useState(0);
-  const [isLoading, setIsLoading] = useState(false); // Estado para loading
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadingKind, setLoadingKind] = useState(null); // "preview" | "process"
+  const [result, setResult] = useState(null); // { url, name, isPreview }
+
+  // close on Escape
+  useEffect(() => {
+    const onKey = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // revoke object URLs on unmount / when replaced
+  const resultRef = useRef(null);
+  useEffect(() => {
+    resultRef.current = result;
+  }, [result]);
+  useEffect(() => {
+    return () => {
+      if (resultRef.current?.url) URL.revokeObjectURL(resultRef.current.url);
+    };
+  }, []);
 
   const handleFileUpload = (event) => {
-    const uploadedFile = event.target.files[0];
-    const allowedExtensions = ["wav", "mp3", "ogg", "flac", "aiff"];
+    const uploaded = event.target.files[0];
+    if (!uploaded) return;
 
-    if (!uploadedFile) {
-      alert("No file selected!");
+    const ext = uploaded.name.split(".").pop().toLowerCase();
+    if (!ALLOWED.includes(ext)) {
+      toast.err(`Unsupported format ".${ext}". Use ${ALLOWED.join(", ")}.`);
       return;
     }
-
-    const fileExtension = uploadedFile.name.split(".").pop().toLowerCase();
-    if (!allowedExtensions.includes(fileExtension)) {
-      alert("Invalid file format. Please upload a valid audio file.");
+    if (uploaded.size > MAX_BYTES) {
+      toast.err("File too large — limit is 80 MB.");
       return;
     }
-    if (uploadedFile.size > 80 * 1024 * 1024) {
-      alert("The file is too large. The limit is 80MB.");
-      return;
-    }
-
-    setFile(uploadedFile);
-    alert(`File '${uploadedFile.name}' uploaded successfully!`);
+    setFile(uploaded);
+    setResult(null);
+    toast.ok(`Loaded "${uploaded.name}".`);
   };
 
   const handleSend = async (preview = false) => {
     if (!file) {
-      alert("Please upload a file before sending!");
+      toast.err("Load an audio file first.");
       return;
     }
 
-    // Bloqueia os botões e ativa o loading
     setIsLoading(true);
+    setLoadingKind(preview ? "preview" : "process");
 
     const normalizedParams = paramValues.map((val, i) => {
       const param = plugin.parameters[i];
@@ -51,102 +70,95 @@ function PluginModal({ plugin, onClose, paramValues, onParameterChange }) {
     });
 
     const params = normalizedParams.map((val, i) => `p${i}=${val}`).join("&");
-    const baseUrl = process.env.REACT_APP_API_BASE_URL || "http://localhost:18080";
+    const baseUrl =
+      process.env.REACT_APP_API_BASE_URL || "http://localhost:18080";
     const url = `${baseUrl}/process?plugin=${plugin.name}&preview=${preview}&previewStartTime=${previewStartTime}&${params}`;
 
     const formData = new FormData();
     formData.append("audio_file", file);
 
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        body: formData,
-      });
+      const response = await fetch(url, { method: "POST", body: formData });
 
       if (!response.ok) {
-        const errorText = await response.text();
+        const errorText = await response.text().catch(() => "");
         console.error(`Server error: ${response.status} - ${errorText}`);
-        alert(`Error processing the file: ${response.status}`);
-        setIsLoading(false);
+        toast.err(`Processing failed (${response.status}).`);
         return;
       }
 
-      const processedFile = await response.blob();
-      if (processedFile.size === 0) {
-        console.error("Received file is empty.");
-        alert("Error: The received file is empty.");
-        setIsLoading(false);
+      const blob = await response.blob();
+      if (blob.size === 0) {
+        toast.err("The server returned an empty file.");
         return;
       }
 
-      // Cria URL de download e aciona o download
-      const downloadUrl = URL.createObjectURL(processedFile);
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      link.download = preview ? "preview_audio.wav" : "processed_audio.wav";
-
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-      alert(
-        preview
-          ? "Preview downloaded successfully!"
-          : "File processed and downloaded successfully!"
-      );
+      // replace previous result (revoke old url)
+      if (resultRef.current?.url) URL.revokeObjectURL(resultRef.current.url);
+      const objectUrl = URL.createObjectURL(blob);
+      setResult({
+        url: objectUrl,
+        name: preview ? "preview_audio.wav" : "processed_audio.wav",
+        isPreview: preview,
+      });
+      toast.ok(preview ? "Preview ready — press play." : "Processed — press play.");
     } catch (error) {
       console.error("Error sending the file:", error);
-      alert("Error processing the file. Please try again.");
+      toast.err("Network error. Please try again.");
     } finally {
       setIsLoading(false);
+      setLoadingKind(null);
     }
   };
 
-  const renderParameterControl = (param, index) => {
+  const renderControl = (param, index) => {
     const value = paramValues[index];
     const displayLabel = param.label || param.name;
+
     switch (param.type) {
       case "slider":
         return (
-          <div key={index} className="param-control slider-control">
-            <label className="param-label">{displayLabel}</label>
-            <Slider
-              min={param.min}
-              max={param.max}
-              step={param.step}
-              value={value}
-              onChange={(val) => onParameterChange(index, val)}
-              disabled={isLoading}  // Desabilita durante o loading
-            />
-            <span className="param-value">{Number(value).toFixed(2)}</span>
-          </div>
+          <Knob
+            key={index}
+            label={displayLabel}
+            value={value}
+            min={param.min}
+            max={param.max}
+            step={param.step}
+            defaultValue={param.defaultValue}
+            disabled={isLoading}
+            color={param.min < 0 ? "cyan" : "sodium"}
+            onChange={(v) => onParameterChange(index, v)}
+          />
         );
+
       case "toggle":
         return (
-          <div key={index} className="param-control toggle-control">
-            <label className="param-label">{displayLabel}</label>
+          <div key={index} className="hw-toggle">
+            <span className="hw-toggle-label">{displayLabel}</span>
             <button
-              onClick={() => {
-                const toggledValue = value === 1.0 ? 0.0 : 1.0;
-                onParameterChange(index, toggledValue);
-              }}
-              className={value === 1.0 ? "toggle-on" : "toggle-off"}
-              disabled={isLoading}  // Desabilita durante o loading
+              type="button"
+              className={`switch ${value === 1.0 ? "on" : "off"}`}
+              onClick={() => onParameterChange(index, value === 1.0 ? 0.0 : 1.0)}
+              disabled={isLoading}
+              aria-pressed={value === 1.0}
             >
-              {value === 1.0 ? "ON" : "OFF"}
+              <span className="switch-track">
+                <span className="switch-thumb" />
+              </span>
+              <span className="switch-state">{value === 1.0 ? "ON" : "OFF"}</span>
             </button>
           </div>
         );
+
       case "select":
         return (
-          <div key={index} className="param-control select-control">
-            <label className="param-label">{displayLabel}</label>
+          <div key={index} className="hw-select">
+            <span className="hw-select-label">{displayLabel}</span>
             <select
               value={value}
-              onChange={(e) =>
-                onParameterChange(index, parseFloat(e.target.value))
-              }
-              disabled={isLoading}  // Desabilita durante o loading
+              onChange={(e) => onParameterChange(index, parseFloat(e.target.value))}
+              disabled={isLoading}
             >
               {param.options.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -156,6 +168,7 @@ function PluginModal({ plugin, onClose, paramValues, onParameterChange }) {
             </select>
           </div>
         );
+
       default:
         return null;
     }
@@ -166,73 +179,90 @@ function PluginModal({ plugin, onClose, paramValues, onParameterChange }) {
       className="modal"
       onClick={(e) => e.target.classList.contains("modal") && onClose()}
     >
-      <div className="modal-content">
-        <button className="close-button" onClick={onClose}>
-          ✖
-        </button>
-
-        <div className="modal-body">
-          <h2 className="modal-title">{plugin.label}</h2>
-          <p className="modal-desc">{plugin.description}</p>
-
-          {file && (
-            <div className="waveform-section">
-              <WaveformSelector
-                file={file}
-                previewStartTime={previewStartTime}
-                setPreviewStartTime={setPreviewStartTime}
-              />
-            </div>
-          )}
-
-          <div className="plugin-controls">
-            <h3 className="params-header">Parameters</h3>
-            <div className="scrollable-section">
-              {plugin.parameters.map((param, i) =>
-                renderParameterControl(param, i)
-              )}
-            </div>
+      <div className="rack-panel">
+        {/* panel head */}
+        <div className="panel-head metal">
+          <span className="screw" />
+          <div className="panel-id">
+            <span className="led" />
+            <span className="panel-slug">{plugin.name}</span>
           </div>
-
-          <div className="file-upload">
-            <label className="file-label">
-              Select Audio File:
-              <input type="file" onChange={handleFileUpload} accept="audio/*" />
-            </label>
-          </div>
+          <h2 className="panel-title">{plugin.label}</h2>
+          <button className="panel-close" onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+          <span className="screw" />
         </div>
 
-        {/* Área fixa para botões e explicação */}
-        <div className="modal-footer">
-          {isLoading ? (
-            <div className="loading-bar">Loading...</div>
-          ) : (
-            <>
-              <div className="button-info">
-                <p>
-                  Choose "Preview" to listen to a short preview starting at the
-                  selected time, or "Process" to apply the effect and download the
-                  processed file.
-                </p>
-              </div>
-              <div className="action-buttons">
-                <button
-                  className="preview-button"
-                  onClick={() => handleSend(true)}
-                  disabled={isLoading}
-                >
-                  Preview
-                </button>
-                <button
-                  className="process-button"
-                  onClick={() => handleSend(false)}
-                  disabled={isLoading}
-                >
-                  Process
-                </button>
-              </div>
-            </>
+        <div className="panel-body">
+          <p className="panel-desc">{plugin.description}</p>
+
+          {/* CRT scope when a file is loaded */}
+          {file && (
+            <WaveformSelector
+              file={file}
+              previewStartTime={previewStartTime}
+              setPreviewStartTime={setPreviewStartTime}
+            />
           )}
+
+          {/* control surface */}
+          <div className="control-surface">
+            <div className="surface-head">
+              <span>PARAMETERS</span>
+              <span className="surface-count">{plugin.parameters.length}</span>
+            </div>
+            <div className="knob-bank">
+              {plugin.parameters.map((param, i) => renderControl(param, i))}
+            </div>
+          </div>
+
+          {/* file slot */}
+          <label className="file-slot">
+            <input type="file" onChange={handleFileUpload} accept="audio/*" />
+            <span className="file-slot-icon">⊕</span>
+            <span className="file-slot-text">
+              {file ? file.name : "Insert audio file (wav · mp3 · ogg · flac · aiff)"}
+            </span>
+          </label>
+
+          {/* result player */}
+          {result && (
+            <div className={`result-bay ${result.isPreview ? "is-preview" : ""}`}>
+              <div className="result-head">
+                <span className="led cyan" />
+                <span>{result.isPreview ? "PREVIEW OUT" : "PROCESSED OUT"}</span>
+                <a className="result-dl" href={result.url} download={result.name}>
+                  ▽ download
+                </a>
+              </div>
+              <audio className="result-audio" src={result.url} controls autoPlay />
+            </div>
+          )}
+        </div>
+
+        {/* transport footer */}
+        <div className="panel-foot metal">
+          <p className="foot-hint">
+            <strong>Preview</strong> renders a short window from the marker ·{" "}
+            <strong>Process</strong> applies to the full file.
+          </p>
+          <div className="transport">
+            <button
+              className="xport-btn xport-preview"
+              onClick={() => handleSend(true)}
+              disabled={isLoading}
+            >
+              {loadingKind === "preview" ? "···" : "▸ Preview"}
+            </button>
+            <button
+              className="xport-btn xport-process"
+              onClick={() => handleSend(false)}
+              disabled={isLoading}
+            >
+              {loadingKind === "process" ? "···" : "● Process"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,0 +1,57 @@
+import React, { createContext, useCallback, useContext, useState } from "react";
+import "../styles/Toast.css";
+
+/*
+ * Minimal toast system to replace alert(). Neon-noir styled.
+ * Usage: const toast = useToast(); toast.ok("done"), toast.err("..."), toast.info("...")
+ */
+
+const ToastCtx = createContext(null);
+
+let _id = 0;
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const dismiss = useCallback((id) => {
+    setToasts((t) => t.filter((x) => x.id !== id));
+  }, []);
+
+  const push = useCallback(
+    (kind, msg, ttl = 4200) => {
+      const id = ++_id;
+      setToasts((t) => [...t, { id, kind, msg }]);
+      if (ttl) setTimeout(() => dismiss(id), ttl);
+      return id;
+    },
+    [dismiss]
+  );
+
+  const api = {
+    ok: (m, ttl) => push("ok", m, ttl),
+    err: (m, ttl) => push("err", m, ttl),
+    info: (m, ttl) => push("info", m, ttl),
+    dismiss,
+  };
+
+  return (
+    <ToastCtx.Provider value={api}>
+      {children}
+      <div className="toast-stack" aria-live="polite">
+        {toasts.map((t) => (
+          <div key={t.id} className={`toast toast-${t.kind}`} onClick={() => dismiss(t.id)}>
+            <span className="toast-led" />
+            <span className="toast-msg">{t.msg}</span>
+            <span className="toast-x">✕</span>
+          </div>
+        ))}
+      </div>
+    </ToastCtx.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastCtx);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/src/components/WaveformSelector.js
+++ b/src/components/WaveformSelector.js
@@ -24,12 +24,14 @@ function WaveformSelector({ file, previewStartTime, setPreviewStartTime }) {
       // Cria a instância do WaveSurfer com o plugin de regiões
       wavesurfer.current = WaveSurfer.create({
         container: waveformRef.current,
-        waveColor: "#6c5ce7",
-        progressColor: "#d63031",
-        cursorColor: "#00cec9",
+        waveColor: "rgba(57, 255, 158, 0.45)",   // dim phosphor
+        progressColor: "#39ff9e",                  // bright phosphor
+        cursorColor: "#ff7a18",                    // sodium marker
+        cursorWidth: 1,
         barWidth: 2,
+        barGap: 1,
         responsive: true,
-        height: 80,
+        height: 96,
         backend: "WebAudio",
         plugins: [
           RegionsPlugin.create({
@@ -51,7 +53,7 @@ function WaveformSelector({ file, previewStartTime, setPreviewStartTime }) {
         const region = wavesurfer.current.addRegion({
           start: 0,
           end: effectiveWindow,
-          color: "rgba(0, 255, 0, 0.3)",
+          color: "rgba(255, 122, 24, 0.18)",
           drag: true,
           resize: false, // Desabilita o redimensionamento para manter a janela fixa
         });
@@ -96,12 +98,16 @@ function WaveformSelector({ file, previewStartTime, setPreviewStartTime }) {
   }, [file, setPreviewStartTime]);
 
   return (
-    <div className="waveform-container">
-      <div className="waveform" ref={waveformRef}></div>
-      <div className="region-info">
-        <p>
-          Preview Start Time: {Number(previewStartTime || 0).toFixed(2)}s | Window: {PREVIEW_WINDOW}s
-        </p>
+    <div className="scope">
+      <div className="scope-screen">
+        <div className="waveform" ref={waveformRef}></div>
+        <div className="scope-glass" aria-hidden="true" />
+      </div>
+      <div className="scope-readout">
+        <span className="led" />
+        <span>MARKER&nbsp;{Number(previewStartTime || 0).toFixed(2)}s</span>
+        <span className="scope-sep">·</span>
+        <span>WINDOW&nbsp;{PREVIEW_WINDOW}s</span>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,66 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+@import "./styles/theme.css";
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--c-void);
+  color: var(--t-default);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin: 0;
+  color: var(--t-bright);
+}
+
+button {
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+input, select, textarea {
+  font-family: var(--font-mono);
+}
+
+code, pre {
+  font-family: var(--font-mono);
+}
+
+/* thin neon-noir scrollbars */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: var(--c-void); }
+::-webkit-scrollbar-thumb {
+  background: var(--c-metal);
+  border-radius: 6px;
+  border: 2px solid var(--c-void);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--c-metal-hi); }
+
+::selection {
+  background: rgba(255, 122, 24, 0.25);
+  color: var(--t-bright);
+}
+
+/* respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { ToastProvider } from './components/Toast';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>
 );
 

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,40 +1,236 @@
+/* ============================================================
+   App shell — night + rain atmosphere, hero, VHS-CRT overlay
+   ============================================================ */
 
-body, html {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  background: #0f0f1a;
-  font-family: 'Courier New', Courier, monospace;
-  color: white;
-}
-
-.app.retro-theme {
-  background: linear-gradient(135deg, #2a1a4d, #1e1340);
+.app {
+  position: relative;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
+  isolation: isolate;            /* contain blend modes */
+  background:
+    /* sodium pool, upper right */
+    radial-gradient(120% 90% at 88% -10%, rgba(255, 122, 24, 0.16) 0%, transparent 45%),
+    /* cyan pool, lower left */
+    radial-gradient(110% 90% at 6% 108%, rgba(25, 182, 201, 0.13) 0%, transparent 42%),
+    /* a distant blood ember, center-low */
+    radial-gradient(80% 60% at 50% 130%, rgba(200, 30, 58, 0.10) 0%, transparent 40%),
+    /* night */
+    linear-gradient(180deg, #07080c 0%, var(--c-base) 45%, #060709 100%);
+  background-attachment: fixed;
+  overflow-x: hidden;
 }
 
+/* ---- Atmosphere: drifting haze + venetian-blind light ---- */
+.atmosphere {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+.atmosphere::before {           /* volumetric haze, slow drift */
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background:
+    radial-gradient(40% 30% at 30% 20%, rgba(255, 176, 102, 0.05), transparent 60%),
+    radial-gradient(45% 35% at 75% 70%, rgba(111, 227, 239, 0.045), transparent 60%);
+  filter: blur(30px);
+  animation: haze-drift 38s var(--ease) infinite alternate;
+}
+.atmosphere::after {            /* venetian-blind light shaft, raking from top-right */
+  content: "";
+  position: absolute;
+  top: -10%; right: -5%;
+  width: 70vw; height: 80vh;
+  background: repeating-linear-gradient(
+    8deg,
+    rgba(255, 122, 24, 0.05) 0px,
+    rgba(255, 122, 24, 0.05) 3px,
+    transparent 3px,
+    transparent 26px
+  );
+  -webkit-mask-image: radial-gradient(60% 60% at 80% 10%, #000 0%, transparent 70%);
+          mask-image: radial-gradient(60% 60% at 80% 10%, #000 0%, transparent 70%);
+  transform: skewX(-6deg);
+  opacity: 0.6;
+}
+
+@keyframes haze-drift {
+  0%   { transform: translate3d(-2%, -1%, 0) scale(1.05); }
+  100% { transform: translate3d(3%, 2%, 0) scale(1.12); }
+}
+
+/* thin diagonal rain, very subtle */
+.rain {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.10;
+  background-image: repeating-linear-gradient(
+    102deg,
+    transparent 0px,
+    transparent 22px,
+    rgba(200, 210, 230, 0.5) 22px,
+    rgba(200, 210, 230, 0.5) 23px
+  );
+  background-size: 100% 200px;
+  animation: rain-fall 0.7s linear infinite;
+  mix-blend-mode: screen;
+}
+@keyframes rain-fall {
+  to { background-position: 60px 200px; }
+}
+
+/* ---- VHS-CRT overlay (on top of everything, never blocks input) ---- */
+.crt-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+}
+.crt-overlay::before {          /* scanlines */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.0) 0px,
+    rgba(0, 0, 0, 0.0) 1px,
+    rgba(0, 0, 0, 0.22) 2px,
+    rgba(0, 0, 0, 0.22) 3px
+  );
+  background-size: 100% 3px;
+  animation: scan-roll 9s linear infinite;
+}
+.crt-overlay::after {           /* vignette + screen curvature darkening + faint flicker */
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 50% 50%, transparent 55%, rgba(0,0,0,0.55) 100%);
+  animation: crt-flicker 5.5s steps(60) infinite;
+}
+@keyframes scan-roll {
+  to { background-position: 0 100vh; }
+}
+@keyframes crt-flicker {
+  0%, 96%, 100% { opacity: 1; }
+  97%  { opacity: 0.86; }
+  98%  { opacity: 1; }
+  99%  { opacity: 0.92; }
+}
+
+/* film grain via fractal noise */
+.grain {
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+  pointer-events: none;
+  opacity: 0.10;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grain-shift 0.5s steps(4) infinite;
+}
+@keyframes grain-shift {
+  0%   { transform: translate(0, 0); }
+  25%  { transform: translate(-3%, 2%); }
+  50%  { transform: translate(2%, -3%); }
+  75%  { transform: translate(-2%, -2%); }
+  100% { transform: translate(3%, 1%); }
+}
+
+/* ---- Content ---- */
 .main-content {
+  position: relative;
+  z-index: 1;
   flex: 1;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 24px 80px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  width: 100%;
-  padding: 20px;
 }
 
-.title {
-  margin: 100px 0 20px 0; /* Adiciona espaço acima para não ser encoberto pela navbar */
-  font-size: 2.5rem;
-  color: #c9a6ff;
+/* ---- Hero ---- */
+.hero {
   text-align: center;
-  font-weight: bold;
+  margin: 132px 0 14px;
+  position: relative;
+}
+.hero-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+  color: var(--c-cyan);
+  text-shadow: var(--txt-cyan);
+  margin-bottom: 14px;
+  opacity: 0.85;
+}
+.title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.4rem, 6vw, 4.4rem);
+  letter-spacing: 0.06em;
+  line-height: 0.96;
+  color: var(--c-sodium-soft);
+  text-shadow: var(--txt-sodium);
+  position: relative;
+}
+.title .accent { color: var(--t-bright); -webkit-text-fill-color: var(--t-bright); }
+
+/* chromatic-aberration glitch on the title — strong, hero only */
+.title::before,
+.title::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.title::before { color: var(--c-cyan);  mix-blend-mode: screen; animation: glitch-x 4.2s steps(40) infinite; }
+.title::after  { color: var(--c-blood); mix-blend-mode: screen; animation: glitch-y 3.1s steps(40) infinite reverse; }
+@keyframes glitch-x {
+  0%, 92%, 100% { transform: translate(0,0); opacity: 0; }
+  93% { transform: translate(-2px, 1px); opacity: 0.7; }
+  96% { transform: translate(2px, -1px); opacity: 0.5; }
+}
+@keyframes glitch-y {
+  0%, 90%, 100% { transform: translate(0,0); opacity: 0; }
+  91% { transform: translate(2px, -1px); opacity: 0.6; }
+  94% { transform: translate(-1px, 1px); opacity: 0.4; }
 }
 
-.full-height {
-  min-height: 100vh;
+.hero-sub {
+  margin-top: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  color: var(--t-dim);
+  letter-spacing: 0.08em;
+  max-width: 540px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.section-rule {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 40px 0 26px;
+  color: var(--t-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+}
+.section-rule::before,
+.section-rule::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, transparent, var(--c-line), transparent);
 }

--- a/src/styles/Knob.css
+++ b/src/styles/Knob.css
@@ -1,0 +1,135 @@
+/* ============================================================
+   Knob — metal/bakelite analog control with amber LED arc
+   ============================================================ */
+
+.knob {
+  --knob-glow: var(--c-sodium);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+  width: 92px;
+}
+.knob-cyan  { --knob-glow: var(--c-cyan); }
+.knob-blood { --knob-glow: var(--c-blood); }
+
+.knob-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-dim);
+  text-align: center;
+  line-height: 1.25;
+  min-height: 1.6em;
+}
+
+.knob-dial {
+  position: relative;
+  width: 76px;
+  height: 76px;
+  cursor: ns-resize;
+  touch-action: none;
+  outline: none;
+}
+.knob-dial:focus-visible {
+  filter: drop-shadow(0 0 4px var(--knob-glow));
+}
+
+/* LED arc ring */
+.knob-ring {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+.knob-ring-track,
+.knob-ring-lit {
+  fill: none;
+  stroke-width: 4;
+  stroke-linecap: round;
+}
+.knob-ring-track {
+  stroke: rgba(255, 255, 255, 0.06);
+}
+.knob-ring-lit {
+  stroke: var(--knob-glow);
+  filter: drop-shadow(0 0 3px var(--knob-glow))
+          drop-shadow(0 0 7px var(--knob-glow));
+  transition: stroke-dasharray 60ms linear;
+}
+
+/* the metal cap */
+.knob-cap {
+  position: absolute;
+  inset: 13px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 38% 30%, #4b505c 0%, #2a2d35 38%, #16181d 72%, #0c0d11 100%);
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.7),
+    inset 0 1px 1px rgba(255, 255, 255, 0.18),
+    inset 0 -3px 6px rgba(0, 0, 0, 0.6);
+  transition: transform 60ms linear;
+}
+/* knurled edge */
+.knob-cap::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(255,255,255,0.05) 0deg 2deg,
+    rgba(0,0,0,0.35) 2deg 4deg
+  );
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 62%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 62%, #000 100%);
+  opacity: 0.8;
+}
+
+/* the pointer notch */
+.knob-pointer {
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  width: 3px;
+  height: 13px;
+  margin-left: -1.5px;
+  border-radius: 2px;
+  background: var(--knob-glow);
+  box-shadow: 0 0 4px var(--knob-glow), 0 0 9px var(--knob-glow);
+}
+
+.knob-readout {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--t-bright);
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 1px 8px;
+  min-width: 56px;
+  text-align: center;
+  box-shadow: var(--shadow-inset);
+  letter-spacing: 0.04em;
+}
+.knob-unit {
+  color: var(--t-dim);
+  margin-left: 2px;
+  font-size: 0.7em;
+}
+
+.knob.is-dragging .knob-cap { transition: none; }
+.knob.is-dragging .knob-readout {
+  color: var(--knob-glow);
+  border-color: var(--knob-glow);
+}
+.knob.is-disabled {
+  opacity: 0.4;
+  pointer-events: none;
+  filter: grayscale(0.5);
+}

--- a/src/styles/LoginModal.css
+++ b/src/styles/LoginModal.css
@@ -1,108 +1,149 @@
-/* LoginModal.css - Estilo Cyberpunk / 80s */
+/* ============================================================
+   LoginModal — neon-noir access terminal
+   ============================================================ */
 
 .login-modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(2px);
+  inset: 0;
+  z-index: 110;
   display: flex;
+  align-items: center;
   justify-content: center;
-  align-items: center;
-  z-index: 2000;
+  padding: 24px;
+  background: rgba(4, 5, 7, 0.74);
+  backdrop-filter: blur(3px) saturate(0.8);
+  animation: modal-fade var(--t-med) var(--ease);
 }
 
-.login-modal-content {
-  /* Fundo gradiente neon roxo-azul para dar ar cyberpunk */
-  background: linear-gradient(135deg, #3a0088, #0abde3);
-  color: #fff;
-  width: 350px;
-  max-width: 95%;
-  padding: 20px;
-  border-radius: 12px;
-  box-shadow: 0 0 15px rgba(58, 0, 136, 0.7);
+.login-panel {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  font-family: 'Courier New', Courier, monospace;
-}
-
-.login-modal-content h2 {
-  margin: 0 0 15px;
-  font-size: 1.8rem;
-  text-shadow: 0 0 8px #ff00d4;
-}
-
-.login-modal-content form {
   width: 100%;
+  max-width: 380px;
+  padding: 26px 26px 22px;
+  background: linear-gradient(180deg, var(--c-surface) 0%, #0c0d12 100%);
+  border: 1px solid #000;
+  border-radius: var(--r-lg);
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.04) inset,
+    0 30px 80px rgba(0,0,0,0.75),
+    0 0 50px rgba(25,182,201,0.07);
+  animation: panel-rise var(--t-med) var(--ease);
+}
+
+.login-panel .panel-close {
+  position: absolute;
+  top: 14px; right: 14px;
+  width: 28px; height: 28px;
+  display: grid;
+  place-items: center;
+  color: var(--t-dim);
+  background: linear-gradient(180deg, #2a2e37, #16181d);
+  border: 1px solid #000;
+  border-radius: var(--r-sm);
+  transition: all var(--t-fast) var(--ease);
+}
+.login-panel .panel-close:hover {
+  color: var(--c-blood-soft);
+  border-color: rgba(200,30,58,0.5);
+  box-shadow: 0 0 8px rgba(200,30,58,0.3);
+}
+
+.login-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.login-head .led { background: var(--c-cyan); box-shadow: var(--glow-cyan); }
+.login-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  color: var(--t-dim);
+}
+.login-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.8rem;
+  letter-spacing: 0.04em;
+  color: var(--c-cyan-soft);
+  text-shadow: var(--txt-cyan);
+  margin-bottom: 18px;
+}
+
+.login-form {
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  margin: 10px 0;
+  gap: 13px;
 }
-
-.login-modal-content input {
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 8px;
-  padding: 10px;
-  color: #fff;
-  font-size: 1rem;
-  transition: background 0.3s;
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
-
-.login-modal-content input:focus {
+.field-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--t-dim);
+}
+.field input {
+  background: var(--c-void);
+  color: var(--t-bright);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  box-shadow: var(--shadow-inset);
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast);
+}
+.field input:focus {
   outline: none;
-  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(25,182,201,0.55);
+  box-shadow: var(--shadow-inset), 0 0 10px rgba(25,182,201,0.2);
 }
 
-.close-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
+.error-msg {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--c-blood-soft);
+  text-shadow: 0 0 8px rgba(200,30,58,0.4);
+}
+
+.login-submit {
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--c-cyan-soft);
+  padding: 11px;
+  border: 1px solid #000;
+  border-radius: var(--r-sm);
+  background: linear-gradient(180deg, #14454d, #0a2a30);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 3px 6px rgba(0,0,0,0.5);
+  transition: all var(--t-fast) var(--ease);
+}
+.login-submit:hover:not(:disabled) {
+  border-color: rgba(25,182,201,0.6);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 0 16px rgba(25,182,201,0.4);
+  text-shadow: var(--txt-cyan);
+}
+.login-submit:active:not(:disabled) { transform: translateY(1px); }
+.login-submit:disabled { opacity: 0.5; cursor: progress; }
+
+.toggle-mode {
+  display: block;
+  width: 100%;
+  margin-top: 16px;
   background: none;
   border: none;
-  font-size: 20px;
-  color: #fff;
-  cursor: pointer;
-  text-shadow: 0 0 5px #ff00d4;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--t-dim);
+  letter-spacing: 0.04em;
+  transition: color var(--t-fast) var(--ease);
 }
-
-.login-modal-content button[type="submit"] {
-  background: #f368e0;
-  color: #fff;
-  font-size: 1rem;
-  border: none;
-  border-radius: 8px;
-  padding: 10px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: background 0.3s, transform 0.2s;
-  box-shadow: 0 0 10px rgba(243, 104, 224, 0.6);
-}
-
-.login-modal-content button[type="submit"]:hover {
-  background: #ff00d4;
-  transform: translateY(-2px);
-}
-
-.toggle-mode-button {
-  background: #01a3a4;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  padding: 10px;
-  font-weight: bold;
-  cursor: pointer;
-  transition: background 0.3s, transform 0.2s;
-  box-shadow: 0 0 10px rgba(1, 163, 164, 0.6);
-}
-
-.toggle-mode-button:hover {
-  background: #00d2d3;
-  transform: translateY(-2px);
-}
+.toggle-mode:hover { color: var(--c-sodium-soft); text-shadow: var(--txt-sodium); }

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -1,87 +1,146 @@
-/* Navbar Cyberpunk Escuro */
+/* ============================================================
+   Navbar — brushed-metal control strip, fixed top
+   ============================================================ */
+
 .navbar {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: linear-gradient(90deg, #2a1a4d, #1e1340);
-  padding: 15px 20px;
-  color: #c9a6ff;
-  border-bottom: 3px solid #7442c8;
-  z-index: 1000;
+  right: 0;
+  z-index: 40;
+  height: 58px;
+  border-bottom: 1px solid #000;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 6px 20px rgba(0, 0, 0, 0.55);
 }
-
-.navbar-left {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-}
-
-/* Estilo para as informações do perfil (nome e créditos) exibidas em duas linhas */
-.profile-info {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.profile-name {
-  font-weight: bold;
-  font-size: 1rem;
-}
-
-.profile-credits {
-  font-size: 0.9rem;
-  color: #d1b3ff;
-}
-
-.navbar-center {
-  flex-grow: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #d1b3ff;
+/* glowing seam under the bar */
+.navbar::after {
+  content: "";
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  width: max-content;
+  left: 0; right: 0; bottom: -1px;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent, rgba(255, 122, 24, 0.5) 30%, rgba(25, 182, 201, 0.5) 70%, transparent);
 }
 
+.navbar-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 1180px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* ---- Brand ---- */
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.brand-mark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.12em;
+  color: var(--c-sodium-soft);
+  text-shadow: var(--txt-sodium);
+}
+.brand-mark span { color: var(--t-bright); }
+.brand-tag {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.2em;
+  color: var(--t-faint);
+  text-transform: uppercase;
+}
+
+/* ---- Right cluster ---- */
 .navbar-right {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  min-width: 150px;
-  padding-right: 20px;
+  gap: 12px;
 }
 
-.navbar-user {
-  font-weight: bold;
+.credits-readout {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 3px 10px;
+  box-shadow: var(--shadow-inset);
+}
+.credits-label {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.18em;
+  color: var(--t-dim);
+}
+.credits-value {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--c-cyan-soft);
+  text-shadow: var(--txt-cyan);
 }
 
-.navbar-credits {
-  font-weight: bold;
+.profile-chip {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.profile-name {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--t-default);
+  letter-spacing: 0.04em;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.profile-chip.guest .profile-name { color: var(--t-dim); }
+
+/* ---- Hardware button ---- */
+.hw-btn {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-bright);
+  background: linear-gradient(180deg, #2a2e37, #16181d);
+  border: 1px solid #000;
+  border-radius: var(--r-sm);
+  padding: 7px 14px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.5);
+  transition: all var(--t-fast) var(--ease);
+}
+.hw-btn:hover {
+  color: var(--c-cyan-soft);
+  border-color: rgba(25, 182, 201, 0.5);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 0 10px rgba(25, 182, 201, 0.3);
+}
+.hw-btn:active { transform: translateY(1px); }
+
+.hw-btn-amber:hover {
+  color: var(--c-sodium-soft);
+  border-color: rgba(255, 122, 24, 0.55);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 0 10px rgba(255, 122, 24, 0.35);
 }
 
-.login-btn {
-  background: #7442c8;
-  color: #fff;
-  font-size: 1rem;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 15px;
-  margin-right: 20px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: background 0.3s, transform 0.2s;
-}
-
-.login-btn:hover {
-  background: #5d2fa1;
-  transform: translateY(-2px);
+@media (max-width: 640px) {
+  .brand-tag, .profile-name { display: none; }
+  .navbar-inner { padding: 0 14px; }
 }

--- a/src/styles/PluginGrid.css
+++ b/src/styles/PluginGrid.css
@@ -1,38 +1,123 @@
+/* ============================================================
+   PluginGrid — analog rack units
+   ============================================================ */
+
 .plugin-grid {
+  width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Aumenta o tamanho mínimo dos cards */
-  gap: 40px; /* Aumenta o espaçamento entre os cards */
-  padding: 20px;
-  max-width: 1400px; /* Aumenta o limite de largura geral */
-  margin: auto;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 20px;
 }
 
-.plugin-card {
-  background: linear-gradient(135deg, #3a0088, #0abde3);
-  padding: 30px; /* Aumenta o tamanho interno do card */
-  border-radius: 15px; /* Bordas mais suaves */
-  text-align: center;
-  transition: transform 0.3s, box-shadow 0.3s;
+.rack-unit {
+  position: relative;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 20px 16px;
+  min-height: 184px;
+  color: var(--t-default);
+  background:
+    linear-gradient(180deg, var(--c-surface) 0%, var(--c-surface-2) 100%);
+  border: 1px solid var(--c-line);
+  border-top-color: #2c303b;
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-rack);
   cursor: pointer;
-  box-shadow: 0 0 20px rgba(58, 0, 136, 0.7);
-  color: white;
-  font-family: 'Courier New', Courier, monospace;
-  text-shadow: 0 0 5px #ff00d4;
-  font-size: 1.2rem; /* Aumenta o tamanho do texto */
-  min-height: 200px; /* Garante um tamanho fixo maior */
+  overflow: hidden;
+  transition: transform var(--t-med) var(--ease),
+              border-color var(--t-med) var(--ease),
+              box-shadow var(--t-med) var(--ease);
+}
+/* faint brushed sheen */
+.rack-unit::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255,255,255,0.04), transparent 30%);
+  pointer-events: none;
+}
+.rack-unit:hover {
+  transform: translateY(-3px);
+  border-color: rgba(255, 122, 24, 0.4);
+  box-shadow:
+    var(--shadow-rack),
+    0 0 0 1px rgba(255, 122, 24, 0.15),
+    0 10px 34px rgba(255, 122, 24, 0.12);
+}
+.rack-unit:hover .led { box-shadow: var(--glow-sodium); }
+.rack-unit:hover .rack-engage { color: var(--c-sodium-soft); text-shadow: var(--txt-sodium); }
+.rack-unit:active { transform: translateY(-1px); }
+
+/* corner screws */
+.rack-unit .screw { position: absolute; }
+.screw-tl { top: 8px; left: 8px; }
+.screw-tr { top: 8px; right: 8px; }
+.screw-bl { bottom: 8px; left: 8px; }
+.screw-br { bottom: 8px; right: 8px; }
+
+.rack-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 6px;
+}
+.rack-head .led { box-shadow: none; background: #5a4326; transition: box-shadow var(--t-med); }
+.rack-id {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  color: var(--t-dim);
+}
+.rack-slug {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--t-faint);
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 1px 6px;
 }
 
-.plugin-card:hover {
-  transform: scale(1.08);
-  box-shadow: 0 0 30px rgba(255, 0, 212, 0.7);
+.rack-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.45rem;
+  letter-spacing: 0.02em;
+  color: var(--t-bright);
+  line-height: 1.05;
+  padding-left: 6px;
+}
+.rack-desc {
+  margin: 0;
+  padding-left: 6px;
+  font-size: 0.82rem;
+  color: var(--t-dim);
+  flex: 1;
 }
 
-.plugin-card h2 {
-  margin-bottom: 15px;
-  font-size: 1.8rem;
+.rack-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 6px 0;
+  border-top: 1px solid var(--c-line);
 }
-
-.plugin-card p {
-  font-size: 1.1rem;
-  opacity: 0.9;
+.rack-params {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t-dim);
+}
+.rack-engage {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--t-default);
+  transition: color var(--t-med), text-shadow var(--t-med);
 }

--- a/src/styles/PluginModal.css
+++ b/src/styles/PluginModal.css
@@ -1,267 +1,339 @@
+/* ============================================================
+   PluginModal — hardware rack panel
+   ============================================================ */
+
 .modal {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
+  z-index: 100;
   display: flex;
+  align-items: flex-start;
   justify-content: center;
-  align-items: center;
-  background-color: rgba(0, 0, 0, 0.8);
-  z-index: 1000;
-}
-
-.modal-content {
-  background-color: #2b2a44;
-  border-radius: 10px;
-  padding: 20px;
-  width: 60%;
-  max-width: 900px;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-  overflow: hidden; /* Evita scroll horizontal na estrutura geral */
-}
-
-.close-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: none;
-  border: none;
-  font-size: 20px;
-  color: #fff;
-  cursor: pointer;
-}
-
-.modal-body {
-  flex: 1;
+  padding: 40px 16px;
   overflow-y: auto;
-  padding-right: 10px; /* Espaço para evitar que o conteúdo fique escondido pelo scrollbar */
+  background: rgba(4, 5, 7, 0.72);
+  backdrop-filter: blur(3px) saturate(0.8);
+  animation: modal-fade var(--t-med) var(--ease);
 }
+@keyframes modal-fade { from { opacity: 0; } to { opacity: 1; } }
 
-.modal-title {
-  margin: 10px 0 5px 0;
-  font-size: 1.8rem;
-  color: #c9a6ff;
-}
-
-.modal-desc {
-  margin: 0 0 15px 0;
-  font-size: 1rem;
-  color: #ffffff;
-  opacity: 0.9;
-  max-width: 90%;
-}
-
-/* Waveform section */
-.waveform-section {
-  margin-bottom: 20px;
+.rack-panel {
   width: 100%;
+  max-width: 720px;
+  margin: auto;
+  background: linear-gradient(180deg, var(--c-surface) 0%, #0c0d12 100%);
+  border: 1px solid #000;
+  border-radius: var(--r-lg);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset,
+    0 30px 80px rgba(0, 0, 0, 0.75),
+    0 0 60px rgba(255, 122, 24, 0.06);
+  overflow: hidden;
+  animation: panel-rise var(--t-med) var(--ease);
+}
+@keyframes panel-rise {
+  from { transform: translateY(16px) scale(0.99); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
 }
 
-/* Contêiner dos controles de parâmetros */
-.plugin-controls {
-  width: 100%;
-  margin-bottom: 20px;
+/* ---- head ---- */
+.panel-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #000;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.05) inset, 0 3px 10px rgba(0,0,0,0.5);
 }
-
-.params-header {
-  font-size: 1.2rem;
-  color: #c9a6ff;
-  margin-bottom: 10px;
+.panel-head .screw { position: relative; z-index: 1; }
+.panel-id {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 1;
+}
+.panel-slug {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
+  color: var(--t-dim);
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 2px 7px;
+}
+.panel-title {
+  flex: 1;
+  z-index: 1;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.03em;
+  color: var(--t-bright);
   text-align: center;
 }
+.panel-close {
+  z-index: 1;
+  width: 30px; height: 30px;
+  display: grid;
+  place-items: center;
+  color: var(--t-dim);
+  background: linear-gradient(180deg, #2a2e37, #16181d);
+  border: 1px solid #000;
+  border-radius: var(--r-sm);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+  transition: all var(--t-fast) var(--ease);
+}
+.panel-close:hover { color: var(--c-blood-soft); border-color: rgba(200,30,58,0.5); box-shadow: 0 0 8px rgba(200,30,58,0.3); }
 
-/* Container rolável apenas verticalmente */
-.scrollable-section {
-  width: 100%;
-  max-height: 250px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 10px;
-  box-sizing: border-box;
-  background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 5px;
+/* ---- body ---- */
+.panel-body {
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.panel-desc {
+  margin: 0;
+  color: var(--t-dim);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
 }
 
-/* Cada controle de parâmetro */
-.param-control {
+/* control surface */
+.control-surface {
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-inset);
+  padding: 14px 16px 18px;
+}
+.surface-head {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  margin: 10px 0;
-  padding: 5px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.22em;
+  color: var(--t-dim);
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--c-line);
 }
-
-.param-label {
-  flex: 1 1 40%;
-  font-size: 14px;
-  color: #fff;
-  text-align: left;
-  word-break: break-all;
+.surface-count {
+  color: var(--c-sodium);
+  text-shadow: var(--txt-sodium);
 }
-
-.slider-control,
-.select-control {
-  flex: 1 1 55%;
+.knob-bank {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 18px 14px;
+  align-items: flex-start;
 }
 
-.slider-control .rc-slider {
-  flex: 1;
-}
-
-.param-value {
-  width: 50px;
-  text-align: right;
-}
-
-/* Toggle control */
-.toggle-control {
-  flex: 1 1 55%;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.toggle-on {
-  background-color: #4caf50;
-  color: #fff;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.toggle-off {
-  background-color: #a9a9a9;
-  color: #fff;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-/* Select control */
-.select-control {
-  flex: 1 1 55%;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.select-control select {
-  flex: 1;
-  background-color: #4a4e69;
-  color: #fff;
-  border: none;
-  padding: 6px;
-  border-radius: 4px;
-}
-
-/* File upload */
-.file-upload {
-  margin-bottom: 20px;
-}
-
-.file-label {
+/* hardware toggle */
+.hw-toggle {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
-  color: #fff;
+  align-items: center;
+  gap: 8px;
+  width: 92px;
 }
-
-.file-label input[type="file"] {
-  margin-top: 5px;
-  padding: 6px;
-  cursor: pointer;
-}
-
-/* Área fixa para botões e texto explicativo */
-.modal-footer {
-  flex-shrink: 0;
-  position: sticky;
-  bottom: 0;
-  background-color: #2b2a44;
-  padding: 10px 0;
-  width: 100%;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.button-info {
+.hw-toggle-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-dim);
   text-align: center;
-  margin-bottom: 10px;
-  color: #fff;
-  font-size: 0.95rem;
-  padding: 0 10px;
+  min-height: 1.6em;
 }
-
-/* Container dos botões de ação */
-.action-buttons {
+.switch {
   display: flex;
-  justify-content: center;
-  gap: 20px;
-  width: 100%;
-  flex-wrap: wrap;
-  overflow-x: hidden;
-}
-
-.preview-button,
-.process-button {
-  padding: 10px 20px;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background: none;
   border: none;
-  border-radius: 5px;
+  padding: 0;
+}
+.switch-track {
+  width: 46px; height: 22px;
+  border-radius: 12px;
+  background: var(--c-void);
+  border: 1px solid var(--c-line);
+  box-shadow: var(--shadow-inset);
+  position: relative;
+  display: block;
+  transition: all var(--t-fast) var(--ease);
+}
+.switch-thumb {
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 38% 30%, #4b505c, #1a1c22);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.7);
+  transition: all var(--t-fast) var(--ease);
+}
+.switch.on .switch-track {
+  background: rgba(255,122,24,0.18);
+  border-color: rgba(255,122,24,0.5);
+}
+.switch.on .switch-thumb {
+  left: 26px;
+  background: radial-gradient(circle at 38% 30%, var(--c-sodium-soft), var(--c-sodium));
+  box-shadow: var(--glow-sodium);
+}
+.switch-state {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--t-dim);
+}
+.switch.on .switch-state { color: var(--c-sodium-soft); text-shadow: var(--txt-sodium); }
+
+/* hardware select */
+.hw-select {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 150px;
+}
+.hw-select-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--t-dim);
+}
+.hw-select select {
+  background: var(--c-void);
+  color: var(--t-bright);
+  border: 1px solid var(--c-line);
+  border-radius: var(--r-sm);
+  padding: 7px 10px;
+  font-size: 0.82rem;
+  box-shadow: var(--shadow-inset);
+}
+.hw-select select:focus { outline: none; border-color: rgba(25,182,201,0.5); }
+
+/* file slot */
+.file-slot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px dashed var(--c-line);
+  border-radius: var(--r-md);
+  background: rgba(0,0,0,0.25);
   cursor: pointer;
-  font-size: 16px;
-  flex: 1;
-  max-width: 150px;
-  min-width: 120px;
+  transition: all var(--t-fast) var(--ease);
+}
+.file-slot:hover { border-color: rgba(25,182,201,0.5); background: rgba(25,182,201,0.05); }
+.file-slot input { display: none; }
+.file-slot-icon {
+  font-size: 1.3rem;
+  color: var(--c-cyan);
+  text-shadow: var(--txt-cyan);
+}
+.file-slot-text {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--t-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.preview-button {
-  background-color: #ff9800;
-  color: #fff;
+/* result bay */
+.result-bay {
+  border: 1px solid rgba(25,182,201,0.35);
+  border-radius: var(--r-md);
+  background: rgba(25,182,201,0.05);
+  padding: 12px 14px;
+  box-shadow: 0 0 18px rgba(25,182,201,0.08) inset;
 }
-
-.preview-button:hover {
-  background-color: #e58900;
+.result-bay.is-preview { border-color: rgba(255,122,24,0.35); background: rgba(255,122,24,0.05); box-shadow: 0 0 18px rgba(255,122,24,0.08) inset; }
+.result-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  color: var(--t-default);
+  margin-bottom: 10px;
 }
-
-.process-button {
-  background-color: #4caf50;
-  color: #fff;
+.result-dl {
+  margin-left: auto;
+  color: var(--c-cyan-soft);
+  text-decoration: none;
+  letter-spacing: 0.08em;
 }
+.result-dl:hover { text-shadow: var(--txt-cyan); }
+.result-audio { width: 100%; height: 38px; filter: saturate(0.7) contrast(1.05); }
 
-.process-button:hover {
-  background-color: #43a047;
+/* ---- foot / transport ---- */
+.panel-foot {
+  padding: 14px 18px;
+  border-top: 1px solid #000;
+  box-shadow: 0 -1px 0 rgba(255,255,255,0.04) inset;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
 }
-
-/* ... Outras regras já existentes ... */
-
-/* Loading bar */
-.loading-bar {
-  width: 100%;
-  text-align: center;
-  padding: 15px 0;
-  color: #fff;
-  font-size: 1.2rem;
+.foot-hint {
+  margin: 0;
+  position: relative;
+  z-index: 1;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--t-dim);
+  max-width: 340px;
+  line-height: 1.4;
 }
+.foot-hint strong { color: var(--t-default); font-weight: 600; }
+.transport { display: flex; gap: 12px; z-index: 1; }
 
-/* Modal-footer já está definido, garantindo que a área de botões fique fixa */
-.modal-footer {
-  flex-shrink: 0;
-  position: sticky;
-  bottom: 0;
-  background-color: #2b2a44;
-  padding: 10px 0;
-  width: 100%;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+.xport-btn {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 11px 22px;
+  border-radius: var(--r-sm);
+  border: 1px solid #000;
+  color: var(--t-bright);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 3px 6px rgba(0,0,0,0.5);
+  transition: all var(--t-fast) var(--ease);
+}
+.xport-preview {
+  background: linear-gradient(180deg, #2a2e37, #16181d);
+}
+.xport-preview:hover:not(:disabled) {
+  color: var(--c-cyan-soft);
+  border-color: rgba(25,182,201,0.55);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 0 14px rgba(25,182,201,0.35);
+}
+.xport-process {
+  background: linear-gradient(180deg, #6a3411, #41200a);
+  color: var(--c-sodium-soft);
+}
+.xport-process:hover:not(:disabled) {
+  border-color: rgba(255,122,24,0.6);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 0 16px rgba(255,122,24,0.45);
+  text-shadow: var(--txt-sodium);
+}
+.xport-btn:active:not(:disabled) { transform: translateY(1px); }
+.xport-btn:disabled { opacity: 0.5; cursor: progress; }
+
+@media (max-width: 560px) {
+  .panel-foot { flex-direction: column; align-items: stretch; }
+  .foot-hint { max-width: none; }
+  .transport { justify-content: stretch; }
+  .xport-btn { flex: 1; }
 }

--- a/src/styles/Toast.css
+++ b/src/styles/Toast.css
@@ -1,0 +1,52 @@
+/* ============================================================
+   Toast — neon-noir notifications
+   ============================================================ */
+
+.toast-stack {
+  position: fixed;
+  bottom: 22px;
+  right: 22px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: min(380px, 90vw);
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 11px 14px;
+  background: linear-gradient(180deg, var(--c-surface) 0%, var(--c-surface-2) 100%);
+  border: 1px solid var(--c-line);
+  border-left-width: 3px;
+  border-radius: var(--r-md);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.6);
+  color: var(--t-default);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  cursor: pointer;
+  animation: toast-in var(--t-med) var(--ease);
+}
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+.toast-led {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.toast-msg { flex: 1; line-height: 1.35; }
+.toast-x { color: var(--t-faint); font-size: 0.7rem; }
+
+.toast-ok   { border-left-color: var(--c-cyan); }
+.toast-ok   .toast-led { background: var(--c-cyan); box-shadow: var(--glow-cyan); }
+.toast-err  { border-left-color: var(--c-blood); }
+.toast-err  .toast-led { background: var(--c-blood); box-shadow: var(--glow-blood); }
+.toast-info { border-left-color: var(--c-sodium); }
+.toast-info .toast-led { background: var(--c-sodium); box-shadow: var(--glow-sodium); }

--- a/src/styles/WaveformSelector.css
+++ b/src/styles/WaveformSelector.css
@@ -1,47 +1,61 @@
-.waveform-container {
-    margin: 20px 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-  }  
+/* ============================================================
+   WaveformSelector — green-phosphor CRT oscilloscope
+   ============================================================ */
 
-  .waveform {
-    width: 100%;
-    max-width: 600px;
-    height: 80px;
-    background: #1e1340; 
-    border-radius: 5px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-    margin-bottom: 15px;
-  }
-  
-  .waveform-controls {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-  }
-  
-  .waveform-controls button {
-    background: #5d2fa1;
-    color: #fff;
-    border: none;
-    padding: 8px 15px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-weight: bold;
-    transition: background 0.3s;
-  }
-  
-  .waveform-controls button:hover {
-    background: #4a2380;
-  }
-  
-  .waveform-controls span {
-    font-size: 1rem;
-    color: #c9a6ff;
-    min-width: 140px;
-    text-align: center;
-  }
-  
+.scope {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scope-screen {
+  position: relative;
+  border-radius: var(--r-md);
+  padding: 10px 12px;
+  background:
+    radial-gradient(120% 130% at 50% 0%, rgba(57,255,158,0.06), transparent 60%),
+    #03060459;
+  background-color: #030604;
+  border: 1px solid #000;
+  box-shadow:
+    inset 0 0 24px rgba(0,0,0,0.9),
+    inset 0 0 40px rgba(57,255,158,0.05),
+    0 0 0 1px rgba(57,255,158,0.08);
+  overflow: hidden;
+}
+
+.waveform {
+  position: relative;
+  z-index: 1;
+  filter: drop-shadow(0 0 3px rgba(57,255,158,0.5));
+}
+
+/* phosphor grid + scanlines + curvature over the screen */
+.scope-glass {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(0deg, rgba(57,255,158,0.05) 0 1px, transparent 1px 22px),
+    repeating-linear-gradient(90deg, rgba(57,255,158,0.05) 0 1px, transparent 1px 22px),
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(0,0,0,0.28) 2px 3px);
+  -webkit-mask-image: radial-gradient(120% 120% at 50% 50%, #000 70%, transparent 100%);
+          mask-image: radial-gradient(120% 120% at 50% 50%, #000 70%, transparent 100%);
+}
+
+.scope-readout {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  color: var(--c-phosphor);
+  text-shadow: var(--glow-phosphor);
+}
+.scope-readout .led { background: var(--c-phosphor); box-shadow: var(--glow-phosphor); }
+.scope-sep { color: var(--t-faint); text-shadow: none; }
+
+/* wavesurfer region handle tint */
+.scope wave region { mix-blend-mode: screen; }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,136 @@
+/* ============================================================
+   retro-vst — neon-noir design tokens
+   Rua-noir Blade Runner: mostly black, isolated pools of light,
+   warm sodium vs cold petrol cyan, blood-red accent. Restraint.
+   See memory: retro-vst-aesthetic
+   ============================================================ */
+
+:root {
+  /* --- Core palette --- */
+  --c-void:        #050507;  /* deepest black, true background floor */
+  --c-base:        #0a0b0f;  /* warm near-black, main surface (night + rain) */
+  --c-surface:     #101218;  /* raised surface (rack chassis) */
+  --c-surface-2:   #161922;  /* panel inset */
+  --c-line:        #20242f;  /* hairlines / seams */
+
+  /* metal — brushed gunmetal for rack hardware */
+  --c-metal-hi:    #3a3f4b;
+  --c-metal:       #23262e;
+  --c-metal-lo:    #14161b;
+  --c-screw:       #2c2f37;
+
+  /* --- Light sources (use sparingly, as glow not fill) --- */
+  --c-sodium:      #ff7a18;  /* warm sodium-vapor amber — primary signal */
+  --c-sodium-soft: #ffb066;
+  --c-cyan:        #19b6c9;  /* cold petrol cyan — secondary / cool data */
+  --c-cyan-soft:   #6fe3ef;
+  --c-blood:       #c81e3a;  /* blood red — danger / accent / WKW red */
+  --c-blood-soft:  #ff4d68;
+  --c-phosphor:    #39ff9e;  /* green CRT phosphor — oscilloscope only */
+
+  /* --- Text --- */
+  --t-bright:      #e8e6df;  /* warm off-white, never pure #fff */
+  --t-default:     #b9b8b0;
+  --t-dim:         #6f7178;
+  --t-faint:       #43454d;
+
+  /* --- Typography --- */
+  --font-display: 'Chakra Petch', 'Saira Condensed', system-ui, sans-serif;
+  --font-mono:    'IBM Plex Mono', 'Courier New', monospace;
+
+  /* --- Glows (neon seen through rain: soft, layered, never hard) --- */
+  --glow-sodium: 0 0 1px var(--c-sodium-soft),
+                 0 0 8px rgba(255, 122, 24, 0.55),
+                 0 0 22px rgba(255, 122, 24, 0.30);
+  --glow-cyan:   0 0 1px var(--c-cyan-soft),
+                 0 0 8px rgba(25, 182, 201, 0.50),
+                 0 0 22px rgba(25, 182, 201, 0.28);
+  --glow-blood:  0 0 1px var(--c-blood-soft),
+                 0 0 8px rgba(200, 30, 58, 0.55),
+                 0 0 22px rgba(200, 30, 58, 0.30);
+  --glow-phosphor: 0 0 4px rgba(57, 255, 158, 0.7),
+                   0 0 14px rgba(57, 255, 158, 0.35);
+
+  /* text-shadow flavors */
+  --txt-sodium: 0 0 6px rgba(255, 122, 24, 0.65), 0 0 18px rgba(255, 122, 24, 0.35);
+  --txt-cyan:   0 0 6px rgba(25, 182, 201, 0.6),  0 0 18px rgba(25, 182, 201, 0.3);
+  --txt-blood:  0 0 6px rgba(200, 30, 58, 0.6),   0 0 18px rgba(200, 30, 58, 0.3);
+
+  /* --- Depth --- */
+  --shadow-rack: 0 1px 0 rgba(255,255,255,0.04) inset,
+                 0 -1px 0 rgba(0,0,0,0.6) inset,
+                 0 12px 30px rgba(0,0,0,0.55);
+  --shadow-inset: inset 0 2px 8px rgba(0,0,0,0.8),
+                  inset 0 -1px 0 rgba(255,255,255,0.03);
+
+  /* --- Geometry --- */
+  --r-sm: 3px;
+  --r-md: 6px;
+  --r-lg: 10px;
+
+  /* --- Motion (slow, Vangelis tempo) --- */
+  --ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --t-fast: 140ms;
+  --t-med: 320ms;
+  --t-slow: 700ms;
+}
+
+/* brushed-metal surface, reused for rack chassis/navbar */
+.metal {
+  background:
+    linear-gradient(180deg, var(--c-metal-hi) 0%, var(--c-metal) 18%, var(--c-metal-lo) 100%);
+  background-color: var(--c-metal);
+  position: relative;
+}
+/* fine vertical brushing */
+.metal::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    90deg,
+    rgba(255,255,255,0.018) 0px,
+    rgba(255,255,255,0.018) 1px,
+    rgba(0,0,0,0.05) 2px,
+    rgba(0,0,0,0.05) 3px
+  );
+  pointer-events: none;
+  mix-blend-mode: overlay;
+  opacity: 0.5;
+}
+
+/* a phillips screw for rack corners */
+.screw {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 30%, #4a4e58 0%, var(--c-screw) 45%, #0c0d11 100%);
+  box-shadow: 0 1px 1px rgba(0,0,0,0.7), inset 0 1px 1px rgba(255,255,255,0.15);
+  position: relative;
+  flex: 0 0 auto;
+}
+.screw::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 8px;
+  height: 1.5px;
+  background: rgba(0,0,0,0.65);
+  transform: rotate(35deg);
+  border-radius: 1px;
+}
+
+/* a small status LED (default amber) */
+.led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--c-sodium);
+  box-shadow: var(--glow-sodium);
+  flex: 0 0 auto;
+}
+.led.cyan  { background: var(--c-cyan);  box-shadow: var(--glow-cyan); }
+.led.blood { background: var(--c-blood); box-shadow: var(--glow-blood); }
+.led.off   { background: #2a2118; box-shadow: none; }


### PR DESCRIPTION
## Resumo
Repaginada completa da casca web com identidade **neon-noir** (Blade Runner rua-noir: preto-chuva, sódio quente × ciano frio, vermelho-sangue), fugindo do clichê outrun/synthwave e do Cyberpunk 2077.

## O que muda
**Fundação**
- `theme.css` com design tokens (paleta, tipografia, glows, helpers metal/screw/led)
- Fontes Chakra Petch (display) + IBM Plex Mono (readout)
- Atmosfera: noite/chuva, névoa, persiana + overlay VHS-CRT (scanlines, grão, vinheta, flicker) fora das zonas interativas

**Componentes**
- `Knob` skeuomórfico (metal/baquelite, anel de LED, drag/scroll/setas/duplo-clique) no lugar do rc-slider
- Navbar de metal escovado, PluginGrid como rack units
- PluginModal como painel de rack com osciloscópio de fósforo verde + transport Preview/Process
- LoginModal "access terminal"

**UX**
- Toasts no lugar de todos os `alert()`
- Áudio processado/preview toca inline (download como ação secundária)
- Login/logout sem `window.location.reload()`; trata 401
- Fix: cadastro deixava a modal aberta (dois setState concorrentes) — agora fecha e mostra o toast de sucesso
- Esc fecha o modal do plugin

**Tooling**
- Playwright MCP no escopo do projeto (`.mcp.json`) + `scripts/shoot.mjs` + devDep playwright

## Notas
- `.env.local` não vai no PR (ignorado; aponta pra produção)
- Integração do catálogo via backend fica pra um próximo PR (rota de listagem ainda não existe no retro-vst-go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
