### PR TITLE
fix: adjust default plugin presets to be audible and musical out of the box

### DIFF
--- a/src/Plugin.json
+++ b/src/Plugin.json
@@ -89,7 +89,7 @@
           "min": -70.05,
           "max": 20.00,
           "step": 0.1,
-          "defaultValue": 0.0
+          "defaultValue": 2.0
         },
         {
           "name": "g_out",
@@ -98,7 +98,7 @@
           "min": -70.05,
           "max": 20.00,
           "step": 0.1,
-          "defaultValue": 0.0
+          "defaultValue": 2.0
         },
         {
           "name": "mode",
@@ -128,7 +128,7 @@
           "min": -68.04,
           "max": 40.00,
           "step": 0.1,
-          "defaultValue": -32.03
+          "defaultValue": 4.0
         },
         {
           "name": "zoom",
@@ -226,7 +226,7 @@
           "min": 10.0,
           "max": 24000.0,
           "step": 10.0,
-          "defaultValue": 1500.0
+          "defaultValue": 15454.7
         },
         {
           "name": "w",
@@ -276,7 +276,7 @@
           "min": -60.0,
           "max": 60.0,
           "step": 0.01,
-          "defaultValue": 0.0
+          "defaultValue": 8.59
         },
         {
           "name": "g_out",
@@ -285,13 +285,13 @@
           "min": -60.0,
           "max": 60.0,
           "step": 0.01,
-          "defaultValue": 0.0
+          "defaultValue": 8.59
         },
         {
           "name": "pause",
           "label": "Pause",
           "type": "toggle",
-          "defaultValue": 1.0
+          "defaultValue": 0.0
         },
         {
           "name": "clear",
@@ -355,7 +355,7 @@
           "name": "scl",
           "label": "Reset Side Chain",
           "type": "toggle",
-          "defaultValue": 1.0
+          "defaultValue": 0.0
         },
         {
           "name": "scs",
@@ -405,7 +405,7 @@
           "min": 10.0,
           "max": 20000.0,
           "step": 1.0,
-          "defaultValue": 12000.0
+          "defaultValue": 10.0
         },
         {
           "name": "slpm",
@@ -423,7 +423,7 @@
           "min": 10.0,
           "max": 20000.0,
           "step": 1.0,
-          "defaultValue": 100.0
+          "defaultValue": 20000.0
         },
         {
           "name": "cm",
@@ -757,7 +757,7 @@
           "min": -100.0,
           "max": 100.0,
           "step": 1.0,
-          "defaultValue": 100.0
+          "defaultValue": 0.0
         },
         {
           "name": "frqs",


### PR DESCRIPTION
This PR adjusts the default parameter values in Plugin.json for the filter-stereo and compressor-stereo plugins to ensure they are audible and musical out of the box.